### PR TITLE
chore: update wasm-bindgen and diesel dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,17 +20,17 @@ targets = ["wasm32-unknown-unknown"]
 talc = { version = "4.4", default-features = false, features = ["lock_api"] }
 diesel = { version = "2.2", features = ["i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
 diesel_derives = "2.2"
-wasm-bindgen = "=0.2.97"
+wasm-bindgen = "=0.2.99"
 wasm-bindgen-futures = "0.4"
 js-sys = { version = "0.3" }
 tracing = { version = "0.1", default-features = false }
 tokio = { version = "1.38", default-features = false, features = ["sync"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-wasm-bindgen = "0.6"
-thiserror = "1"
+thiserror = "2"
 
 [dev-dependencies]
-wasm-bindgen-test = "=0.3.47"
+wasm-bindgen-test = "=0.3.49"
 console_error_panic_hook = { version = "0.1"}
 rand = "0.8"
 getrandom = { version = "0.2", features = ["js"] }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency versions for improved performance and compatibility:
		- `wasm-bindgen` updated to `0.2.99`
		- `thiserror` updated to `2`
		- `wasm-bindgen-test` updated to `0.3.49`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->